### PR TITLE
Automatically refresh report preview when the date changes

### DIFF
--- a/DailyReportTemplate/Reports/DP.aspx
+++ b/DailyReportTemplate/Reports/DP.aspx
@@ -115,7 +115,8 @@
 <div class="toolbar">
     <div class="field">
         <label for="txtDate">Report Date</label>
-        <asp:TextBox ID="txtDate" runat="server" CssClass="text" TextMode="Date" />
+        <asp:TextBox ID="txtDate" runat="server" CssClass="text" TextMode="Date"
+            AutoPostBack="true" OnTextChanged="txtDate_TextChanged" />
         <asp:RequiredFieldValidator ID="rfvDate" runat="server" ControlToValidate="txtDate"
             ErrorMessage="*" CssClass="val" Display="Dynamic" />
     </div>

--- a/DailyReportTemplate/Reports/DP.aspx.vb
+++ b/DailyReportTemplate/Reports/DP.aspx.vb
@@ -47,6 +47,10 @@ Public Class DP
         BindGrid()
     End Sub
 
+    Protected Sub txtDate_TextChanged(sender As Object, e As EventArgs) Handles txtDate.TextChanged
+        BindGrid()
+    End Sub
+
     Protected Sub btnExportTemplate_Click(sender As Object, e As EventArgs) Handles btnExportExcel.Click
         Try
             Dim d = SelectedDate()


### PR DESCRIPTION
## Summary
- trigger a postback whenever the report date is edited
- bind the grid in response to the date change so the preview refreshes automatically

## Testing
- not run (project targets .NET Framework and cannot be built in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5b1dc30448322bc9db67aaba4f833