### PR TITLE
Ensure manual entry respects selected date

### DIFF
--- a/DailyReportTemplate/Reports/DP.aspx
+++ b/DailyReportTemplate/Reports/DP.aspx
@@ -140,7 +140,7 @@
 
     <div class="field" style="min-width:160px">
         <label>&nbsp;</label>
-        <a class="btn" href="ManualEntry.aspx">Manual Entry</a>
+        <asp:HyperLink ID="lnkManualEntry" runat="server" CssClass="btn" Text="Manual Entry" />
     </div>
 
     <div class="field" style="min-width:200px">

--- a/DailyReportTemplate/Reports/DP.aspx.designer.vb
+++ b/DailyReportTemplate/Reports/DP.aspx.designer.vb
@@ -68,6 +68,15 @@ Partial Public Class DP
     Protected WithEvents btnRefresh As Global.System.Web.UI.WebControls.Button
 
     '''<summary>
+    '''lnkManualEntry control.
+    '''</summary>
+    '''<remarks>
+    '''Auto-generated field.
+    '''To modify move field declaration from designer file to code-behind file.
+    '''</remarks>
+    Protected WithEvents lnkManualEntry As Global.System.Web.UI.WebControls.HyperLink
+
+    '''<summary>
     '''btnExportExcel control.
     '''</summary>
     '''<remarks>

--- a/DailyReportTemplate/Reports/DP.aspx.vb
+++ b/DailyReportTemplate/Reports/DP.aspx.vb
@@ -27,6 +27,7 @@ Public Class DP
 
     Private Sub BindGrid()
         Dim d = SelectedDate()
+        UpdateManualEntryLink(d)
         Dim dt = repo.GetFacts(d)
         gv.DataSource = dt
         gv.DataBind()
@@ -35,6 +36,12 @@ Public Class DP
             lblInfo.Text = $"No data for {d:yyyy-MM-dd}. Build it first."
         Else
             lblInfo.Text = $"Loaded {dt.Rows.Count:n0} rows for {d:yyyy-MM-dd}."
+        End If
+    End Sub
+
+    Private Sub UpdateManualEntryLink(reportDate As Date)
+        If lnkManualEntry IsNot Nothing Then
+            lnkManualEntry.NavigateUrl = $"ManualEntry.aspx?date={reportDate:yyyy-MM-dd}"
         End If
     End Sub
 

--- a/DailyReportTemplate/Reports/ManualEntry.aspx
+++ b/DailyReportTemplate/Reports/ManualEntry.aspx
@@ -89,11 +89,12 @@
             <div class="toolbar">
                 <div class="field">
                     <label for="txtDate">Report Date</label>
-                    <asp:TextBox ID="txtDate" runat="server" CssClass="text" TextMode="Date" />
+                    <asp:TextBox ID="txtDate" runat="server" CssClass="text" TextMode="Date"
+                        AutoPostBack="true" OnTextChanged="txtDate_TextChanged" />
                 </div>
                 <div class="field" style="min-width:150px">
                     <label>&nbsp;</label>
-                    <asp:Button ID="btnLoadPrevious" runat="server" CssClass="btn ghost" Text="Load Previous Day" />
+                    <asp:Button ID="btnReload" runat="server" CssClass="btn ghost" Text="Reload Form" />
                 </div>
                 <div class="spacer"></div>
                 <div class="field" style="min-width:160px">

--- a/DailyReportTemplate/Reports/ManualEntry.aspx.designer.vb
+++ b/DailyReportTemplate/Reports/ManualEntry.aspx.designer.vb
@@ -24,9 +24,9 @@ Partial Public Class ManualEntry
     Protected WithEvents txtDate As Global.System.Web.UI.WebControls.TextBox
 
     '''<summary>
-    '''btnLoadPrevious control.
+    '''btnReload control.
     '''</summary>
-    Protected WithEvents btnLoadPrevious As Global.System.Web.UI.WebControls.Button
+    Protected WithEvents btnReload As Global.System.Web.UI.WebControls.Button
 
     '''<summary>
     '''btnSave control.

--- a/DailyReportTemplate/Reports/ManualEntry.aspx.vb
+++ b/DailyReportTemplate/Reports/ManualEntry.aspx.vb
@@ -20,10 +20,21 @@ Partial Public Class ManualEntry
 
     Protected Sub Page_Load(ByVal sender As Object, ByVal e As EventArgs) Handles Me.Load
         If Not IsPostBack Then
-            txtDate.Text = Date.Today.ToString("yyyy-MM-dd")
-            LoadValuesForDate(SelectedDate())
+            Dim requested = RequestedDateFromQuery()
+            Dim initial = If(requested.HasValue, requested.Value, Date.Today)
+            txtDate.Text = initial.ToString("yyyy-MM-dd")
+            LoadValuesForDate(initial)
         End If
     End Sub
+
+    Private Function RequestedDateFromQuery() As Nullable(Of Date)
+        Dim raw = Request.QueryString("date")
+        Dim parsed As Date
+        If Not String.IsNullOrWhiteSpace(raw) AndAlso Date.TryParse(raw, parsed) Then
+            Return parsed
+        End If
+        Return Nothing
+    End Function
 
     Private Function SelectedDate() As Date
         Dim d As Date
@@ -127,15 +138,12 @@ Partial Public Class ManualEntry
         Next
     End Sub
 
-    Protected Sub btnLoadPrevious_Click(sender As Object, e As EventArgs) Handles btnLoadPrevious.Click
-        Dim prev = SelectedDate().AddDays(-1)
-        Dim dict = repo.GetFactsAsDictionary(prev)
-        ApplyValues(dict)
-        If dict.Count = 0 Then
-            lblStatus.Text = "No saved values for " & prev.ToString("yyyy-MM-dd") & "."
-        Else
-            lblStatus.Text = "Loaded " & dict.Count.ToString(CultureInfo.InvariantCulture) & " values from " & prev.ToString("yyyy-MM-dd") & ". Click Save to persist for " & SelectedDate().ToString("yyyy-MM-dd") & "."
-        End If
+    Protected Sub txtDate_TextChanged(sender As Object, e As EventArgs) Handles txtDate.TextChanged
+        LoadValuesForDate(SelectedDate())
+    End Sub
+
+    Protected Sub btnReload_Click(sender As Object, e As EventArgs) Handles btnReload.Click
+        LoadValuesForDate(SelectedDate())
     End Sub
 
     Protected Sub btnSave_Click(sender As Object, e As EventArgs) Handles btnSave.Click


### PR DESCRIPTION
## Summary
- pass the selected report date from DP.aspx to the manual entry link
- initialize the manual entry form from the requested date and reload when the date changes
- replace the load previous day action with a manual reload button

## Testing
- Not Run (build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d65853896883228ac06876e990e25b